### PR TITLE
Improve `RecipeChoice` support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -68,12 +68,6 @@
             <scope>compile</scope>
         </dependency>
         <dependency>
-            <groupId>it.multicoredev.mbcore.spigot</groupId>
-            <artifactId>MBCore-spigot</artifactId>
-            <version>7.5.3</version>
-            <scope>compile</scope>
-        </dependency>
-        <dependency>
             <groupId>de.tr7zw</groupId>
             <artifactId>item-nbt-api</artifactId>
             <version>2.12.0</version>

--- a/src/main/java/it/multicoredev/nbtr/Chat.java
+++ b/src/main/java/it/multicoredev/nbtr/Chat.java
@@ -1,0 +1,935 @@
+package it.multicoredev.nbtr;
+
+import com.google.common.base.Preconditions;
+import com.google.gson.JsonSyntaxException;
+import org.bukkit.Bukkit;
+import org.bukkit.ChatColor;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.logging.Level;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+/**
+ * Copyright © 2020 by Lorenzo Magni
+ * This file is part of MBCore.
+ * MBCore is under "The 3-Clause BSD License", you can find a copy <a href="https://opensource.org/licenses/BSD-3-Clause">here</a>.
+ * <p>
+ * Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+ * 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following
+ * disclaimer in the documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products
+ * derived from this software without specific prior written permission.
+ * <p>
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING,
+ * BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+ * OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+ * OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+public class Chat {
+    private final static Pattern hexColorPattern = Pattern.compile("#([A-Fa-f0-9]{6})");
+    private static Boolean useAllColors = null;
+
+    private static String translateHex(String msg) {
+        Preconditions.checkNotNull(msg, "Cannot translate null text");
+
+        if (useAllColors == null) {
+            Matcher matcher = Pattern.compile("[0-9]\\.[0-9]+").matcher(Bukkit.getBukkitVersion());
+
+            if (matcher.find()) {
+                try {
+                    useAllColors = Integer.parseInt(matcher.group(0).split("\\.")[1]) >= 16;
+                } catch (NumberFormatException ignored) {
+                }
+            }
+        }
+
+        if (!useAllColors) return msg;
+
+        Matcher matcher = hexColorPattern.matcher(msg);
+        while (matcher.find()) {
+            String match = matcher.group(0);
+            msg = msg.replace(match, net.md_5.bungee.api.ChatColor.of(match) + "");
+        }
+
+        return msg;
+    }
+
+    /**
+     * Convert '&amp;' color codes to Minecraft understandable color codes.
+     *
+     * @param msg The message to convert.
+     * @return The converted message.
+     */
+    public static String getTranslated(String msg) {
+        if (msg == null) return null;
+        msg = msg.replace("&g", "#2196F3").replace("&h", "#2962FF");
+        msg = ChatColor.translateAlternateColorCodes('&', msg);
+        msg = translateHex(msg);
+        return msg;
+    }
+
+    /**
+     * Convert '&amp;' color codes to Minecraft understandable color codes if the sender has one or more permissions.
+     *
+     * @param msg         The message to convert.
+     * @param sender      The sender of the message.
+     * @param permissions One or more permissions to check.
+     * @return The converted message.
+     */
+    public static String getTranslated(String msg, Player sender, String... permissions) {
+        if (hasPermission(sender, permissions)) return getTranslated(msg);
+        return msg;
+    }
+
+    /**
+     * Convert '&amp;' color codes to Minecraft understandable color codes if the sender has one or more permissions.
+     *
+     * @param msg         The message to convert.
+     * @param sender      The sender of the message.
+     * @param permissions One or more permissions to check.
+     * @return The converted message.
+     */
+    public static String getTranslated(String msg, CommandSender sender, String... permissions) {
+        if (sender instanceof Player) return getTranslated(msg, (Player) sender, permissions);
+        return getTranslated(msg);
+    }
+
+    /**
+     * Convert '&amp;' color codes to Minecraft understandable color codes.
+     *
+     * @param msgs The messages to convert.
+     * @return The converted messages.
+     */
+    public static String[] getTranslated(String[] msgs) {
+        for (int i = 0; i < msgs.length; i++) {
+            String msg = msgs[i];
+            if (msg == null) return null;
+            msg = msg.replace("&g", "#2196F3").replace("&h", "#2962FF");
+            msg = ChatColor.translateAlternateColorCodes('&', msg);
+            msg = translateHex(msg);
+            msgs[i] = msg;
+        }
+
+        return msgs;
+    }
+
+    /**
+     * Convert '&amp;' color codes to Minecraft understandable color codes if the sender has one or more permissions.
+     *
+     * @param msgs        The messages to convert.
+     * @param sender      The sender of the message.
+     * @param permissions One or more permissions to check.
+     * @return The converted messages.
+     */
+    public static String[] getTranslated(String[] msgs, Player sender, String... permissions) {
+        if (hasPermission(sender, permissions)) return getTranslated(msgs);
+        return msgs;
+    }
+
+    /**
+     * Convert '&amp;' color codes to Minecraft understandable color codes if the sender has one or more permissions.
+     *
+     * @param msgs        The messages to convert.
+     * @param sender      The sender of the message.
+     * @param permissions One or more permissions to check.
+     * @return The converted messages.
+     */
+    public static String[] getTranslated(String[] msgs, CommandSender sender, String... permissions) {
+        if (sender instanceof Player) return getTranslated(msgs, (Player) sender, permissions);
+        return getTranslated(msgs);
+    }
+
+    /**
+     * Convert '&amp;' color codes to Minecraft understandable color codes.
+     *
+     * @param msgs The messages to convert.
+     * @return The converted messages.
+     */
+    public static List<String> getTranslated(List<String> msgs) {
+        List<String> out = new ArrayList<>();
+        for (String msg : msgs) {
+            if (msg == null) return null;
+            msg = msg.replace("&g", "#2196F3").replace("&h", "#2962FF");
+            msg = net.md_5.bungee.api.ChatColor.translateAlternateColorCodes('&', msg);
+            msg = translateHex(msg);
+            out.add(msg);
+        }
+
+        return out;
+    }
+
+    /**
+     * Convert '&amp;' color codes to Minecraft understandable color codes if the sender has one or more permissions.
+     *
+     * @param msgs        The messages to convert.
+     * @param sender      The sender of the message.
+     * @param permissions One or more permissions to check.
+     * @return The converted messages.
+     */
+    public static List<String> getTranslated(List<String> msgs, Player sender, String... permissions) {
+        if (hasPermission(sender, permissions)) return getTranslated(msgs);
+        return msgs;
+    }
+
+    /**
+     * Convert '&amp;' color codes to Minecraft understandable color codes if the sender has one or more permissions.
+     *
+     * @param msgs        The messages to convert.
+     * @param sender      The sender of the message.
+     * @param permissions One or more permissions to check.
+     * @return The converted messages.
+     */
+    public static List<String> getTranslated(List<String> msgs, CommandSender sender, String... permissions) {
+        if (sender instanceof Player) return getTranslated(msgs, (Player) sender, permissions);
+        return getTranslated(msgs);
+    }
+
+    /**
+     * Remove all '&amp;' color codes.
+     *
+     * @param msg The message to convert.
+     * @return The converted message.
+     */
+    public static String getDiscolored(String msg) {
+        if (msg == null) return null;
+
+        msg = msg.replaceAll("&[0-9a-hA-HkKlLmMnNoOrR]", "");
+        msg = msg.replaceAll("§[0-9a-hA-HkKlLmMnNoOrR]", "");
+
+        Matcher matcher = hexColorPattern.matcher(msg);
+        while (matcher.find()) {
+            String match = matcher.group(0);
+            msg = msg.replace(match, "");
+        }
+
+        return msg;
+    }
+
+    /**
+     * Remove all '&amp;' color codes.
+     *
+     * @param msgs The messages to convert.
+     * @return The converted messages.
+     */
+    public static String[] getDiscolored(String[] msgs) {
+        if (msgs == null) return null;
+
+        for (int i = 0; i < msgs.length; i++) {
+            String msg = msgs[i];
+            msg = msg.replaceAll("&[0-9a-hA-HkKlLmMnNoOrR]", "");
+            msg = msg.replaceAll("§[0-9a-hA-HkKlLmMnNoOrR]", "");
+
+            Matcher matcher = hexColorPattern.matcher(msg);
+            while (matcher.find()) {
+                String match = matcher.group(0);
+                msg = msg.replace(match, "");
+            }
+
+            msgs[i] = msg;
+        }
+
+        return msgs;
+    }
+
+    /**
+     * Remove all '&amp;' color codes.
+     *
+     * @param msgs The messages to convert.
+     * @return The converted messages.
+     */
+    public static List<String> getDiscolored(List<String> msgs) {
+        if (msgs == null) return null;
+
+        for (String msg : msgs) {
+            msg = msg.replaceAll("&[0-9a-hA-HkKlLmMnNoOrR]", "");
+            msg = msg.replaceAll("§[0-9a-hA-HkKlLmMnNoOrR]", "");
+
+            Matcher matcher = hexColorPattern.matcher(msg);
+            while (matcher.find()) {
+                String match = matcher.group(0);
+                msg = msg.replace(match, "");
+            }
+        }
+
+        return msgs;
+    }
+
+    /**
+     * Join string arguments starting from an offset.
+     *
+     * @param args   The arguments to join.
+     * @param offset The offset.
+     * @return The joined string.
+     */
+    public static String builder(String[] args, int offset) {
+        StringBuilder builder = new StringBuilder();
+        for (; offset < args.length; offset++) builder.append(args[offset]).append(" ");
+        return builder.toString();
+    }
+
+    /**
+     * Join string arguments.
+     *
+     * @param args The arguments to join.
+     * @return The joined string.
+     */
+    public static String builder(String[] args) {
+        return builder(args, 0);
+    }
+
+    /**
+     * Send a message to a player.
+     *
+     * @param msg       The message to be sent.
+     * @param receiver  The receiver of the message.
+     * @param translate Convert the color codes.
+     */
+    public static void send(String msg, Player receiver, boolean translate) {
+        receiver.sendMessage(translate ? getTranslated(msg) : msg);
+    }
+
+    /**
+     * Send a message to a player.
+     *
+     * @param msg      The message to be sent.
+     * @param receiver The receiver of the message.
+     */
+    public static void send(String msg, Player receiver) {
+        send(msg, receiver, true);
+    }
+
+    /**
+     * Send a message to a player.
+     *
+     * @param msg         The message to be sent.
+     * @param receiver    The receiver of the message.
+     * @param sender      The sender of the message.
+     * @param permissions Convert the color codes if the sender has this permissions.
+     */
+    public static void send(String msg, Player receiver, Player sender, String... permissions) {
+        receiver.sendMessage(getTranslated(msg, sender, permissions));
+    }
+
+    /**
+     * Send a message to a player.
+     *
+     * @param msg         The message to be sent.
+     * @param receiver    The receiver of the message.
+     * @param sender      The sender of the message.
+     * @param permissions Convert the color codes if the sender has this permissions.
+     */
+    public static void send(String msg, Player receiver, CommandSender sender, String... permissions) {
+        receiver.sendMessage(getTranslated(msg, sender, permissions));
+    }
+
+    /**
+     * Send a message to a player.
+     *
+     * @param msg       The message to be sent.
+     * @param receiver  The receiver of the message.
+     * @param translate Convert the color codes.
+     */
+    public static void send(String msg, CommandSender receiver, boolean translate) {
+        receiver.sendMessage(translate ? getTranslated(msg) : msg);
+    }
+
+    /**
+     * Send a message to a player.
+     *
+     * @param msg      The message to be sent.
+     * @param receiver The receiver of the message.
+     */
+    public static void send(String msg, CommandSender receiver) {
+        send(msg, receiver, true);
+    }
+
+    /**
+     * Send a message to a player.
+     *
+     * @param msg         The message to be sent.
+     * @param receiver    The receiver of the message.
+     * @param sender      The sender of the message.
+     * @param permissions Convert the color codes if the sender has this permissions.
+     */
+    public static void send(String msg, CommandSender receiver, Player sender, String... permissions) {
+        receiver.sendMessage(getTranslated(msg, sender, permissions));
+    }
+
+    /**
+     * Send a message to a player.
+     *
+     * @param msg         The message to be sent.
+     * @param receiver    The receiver of the message.
+     * @param sender      The sender of the message.
+     * @param permissions Convert the color codes if the sender has this permissions.
+     */
+    public static void send(String msg, CommandSender receiver, CommandSender sender, String... permissions) {
+        receiver.sendMessage(getTranslated(msg, sender, permissions));
+    }
+
+    /**
+     * Send a message to a player.
+     *
+     * @param msgs      The messages to be sent.
+     * @param receiver  The receiver of the message.
+     * @param translate Convert the color codes.
+     */
+    public static void send(String[] msgs, Player receiver, boolean translate) {
+        for (String msg : msgs) {
+            receiver.sendMessage(translate ? getTranslated(msg) : msg);
+        }
+    }
+
+    /**
+     * Send a message to a player.
+     *
+     * @param msgs     The messages to be sent.
+     * @param receiver The receiver of the message.
+     */
+    public static void send(String[] msgs, Player receiver) {
+        send(msgs, receiver, true);
+    }
+
+    /**
+     * Send a message to a player.
+     *
+     * @param msgs        The messages to be sent.
+     * @param receiver    The receiver of the message.
+     * @param sender      The sender of the message.
+     * @param permissions Convert the color codes if the sender has this permissions.
+     */
+    public static void send(String[] msgs, Player receiver, Player sender, String... permissions) {
+        for (String msg : msgs) {
+            receiver.sendMessage(getTranslated(msg, sender, permissions));
+        }
+    }
+
+    /**
+     * Send a message to a player.
+     *
+     * @param msgs        The messages to be sent.
+     * @param receiver    The receiver of the message.
+     * @param sender      The sender of the message.
+     * @param permissions Convert the color codes if the sender has this permissions.
+     */
+    public static void send(String[] msgs, Player receiver, CommandSender sender, String... permissions) {
+        for (String msg : msgs) {
+            receiver.sendMessage(getTranslated(msg, sender, permissions));
+        }
+    }
+
+    /**
+     * Send a message to a player.
+     *
+     * @param msgs      The messages to be sent.
+     * @param receiver  The receiver of the message.
+     * @param translate Convert the color codes.
+     */
+    public static void send(String[] msgs, CommandSender receiver, boolean translate) {
+        for (String msg : msgs) {
+            receiver.sendMessage(translate ? getTranslated(msg) : msg);
+        }
+    }
+
+    /**
+     * Send a message to a player.
+     *
+     * @param msgs     The messages to be sent.
+     * @param receiver The receiver of the message.
+     */
+    public static void send(String[] msgs, CommandSender receiver) {
+        send(msgs, receiver, true);
+    }
+
+    /**
+     * Send a message to a player.
+     *
+     * @param msgs        The messages to be sent.
+     * @param receiver    The receiver of the message.
+     * @param sender      The sender of the message.
+     * @param permissions Convert the color codes if the sender has this permissions.
+     */
+    public static void send(String[] msgs, CommandSender receiver, Player sender, String... permissions) {
+        for (String msg : msgs) {
+            receiver.sendMessage(getTranslated(msg, sender, permissions));
+        }
+
+    }
+
+    /**
+     * Send a message to a player.
+     *
+     * @param msgs        The messages to be sent.
+     * @param receiver    The receiver of the message.
+     * @param sender      The sender of the message.
+     * @param permissions Convert the color codes if the sender has this permissions.
+     */
+    public static void send(String[] msgs, CommandSender receiver, CommandSender sender, String... permissions) {
+        for (String msg : msgs) {
+            receiver.sendMessage(getTranslated(msg, sender, permissions));
+        }
+    }
+
+    /**
+     * Send a message to a player.
+     *
+     * @param msgs      The messages to be sent.
+     * @param receiver  The receiver of the message.
+     * @param translate Convert the color codes.
+     */
+    public static void send(List<String> msgs, Player receiver, boolean translate) {
+        for (String msg : msgs) {
+            receiver.sendMessage(translate ? getTranslated(msg) : msg);
+        }
+    }
+
+    /**
+     * Send a message to a player.
+     *
+     * @param msgs     The messages to be sent.
+     * @param receiver The receiver of the message.
+     */
+    public static void send(List<String> msgs, Player receiver) {
+        send(msgs, receiver, true);
+    }
+
+    /**
+     * Send a message to a player.
+     *
+     * @param msgs        The messages to be sent.
+     * @param receiver    The receiver of the message.
+     * @param sender      The sender of the message.
+     * @param permissions Convert the color codes if the sender has this permissions.
+     */
+    public static void send(List<String> msgs, Player receiver, Player sender, String... permissions) {
+        for (String msg : msgs) {
+            receiver.sendMessage(getTranslated(msg, sender, permissions));
+        }
+    }
+
+    /**
+     * Send a message to a player.
+     *
+     * @param msgs        The messages to be sent.
+     * @param receiver    The receiver of the message.
+     * @param sender      The sender of the message.
+     * @param permissions Convert the color codes if the sender has this permissions.
+     */
+    public static void send(List<String> msgs, Player receiver, CommandSender sender, String... permissions) {
+        for (String msg : msgs) {
+            receiver.sendMessage(getTranslated(msg, sender, permissions));
+        }
+    }
+
+    /**
+     * Send a message to a player.
+     *
+     * @param msgs      The messages to be sent.
+     * @param receiver  The receiver of the message.
+     * @param translate Convert the color codes.
+     */
+    public static void send(List<String> msgs, CommandSender receiver, boolean translate) {
+        for (String msg : msgs) {
+            receiver.sendMessage(translate ? getTranslated(msg) : msg);
+        }
+    }
+
+    /**
+     * Send a message to a player.
+     *
+     * @param msgs     The messages to be sent.
+     * @param receiver The receiver of the message.
+     */
+    public static void send(List<String> msgs, CommandSender receiver) {
+        send(msgs, receiver, true);
+    }
+
+    /**
+     * Send a message to a player.
+     *
+     * @param msgs        The messages to be sent.
+     * @param receiver    The receiver of the message.
+     * @param sender      The sender of the message.
+     * @param permissions Convert the color codes if the sender has this permissions.
+     */
+    public static void send(List<String> msgs, CommandSender receiver, Player sender, String... permissions) {
+        for (String msg : msgs) {
+            receiver.sendMessage(getTranslated(msg, sender, permissions));
+        }
+
+    }
+
+    /**
+     * Send a message to a player.
+     *
+     * @param msgs        The messages to be sent.
+     * @param receiver    The receiver of the message.
+     * @param sender      The sender of the message.
+     * @param permissions Convert the color codes if the sender has this permissions.
+     */
+    public static void send(List<String> msgs, CommandSender receiver, CommandSender sender, String... permissions) {
+        for (String msg : msgs) {
+            receiver.sendMessage(getTranslated(msg, sender, permissions));
+        }
+    }
+
+    /**
+     * Broadcast a message to all players.
+     *
+     * @param msg       The message to be broadcast.
+     * @param translate Convert the color codes.
+     */
+    public static void broadcast(String msg, boolean translate) {
+        for (Player player : Bukkit.getOnlinePlayers()) {
+            send(msg, player, translate);
+        }
+    }
+
+    /**
+     * Broadcast a message to all players.
+     *
+     * @param msg The message to be broadcast.
+     */
+    public static void broadcast(String msg) {
+        broadcast(msg, true);
+    }
+
+    /**
+     * Broadcast a message to all players.
+     *
+     * @param msg         The message to be broadcast.
+     * @param sender      The sender of the message.
+     * @param permissions Convert the color codes if the sender has this permissions.
+     */
+    public static void broadcast(String msg, Player sender, String... permissions) {
+        for (Player player : Bukkit.getOnlinePlayers()) {
+            send(msg, player, sender, permissions);
+        }
+    }
+
+    /**
+     * Broadcast a message to all players.
+     *
+     * @param msg         The message to be broadcast.
+     * @param sender      The sender of the message.
+     * @param permissions Convert the color codes if the sender has this permissions.
+     */
+    public static void broadcast(String msg, CommandSender sender, String... permissions) {
+        for (Player player : Bukkit.getOnlinePlayers()) {
+            send(msg, player, sender, permissions);
+        }
+    }
+
+    /**
+     * Broadcast a message to all players except blacklisted ones.
+     *
+     * @param msg       The message to be broadcast.
+     * @param translate Convert the color codes.
+     * @param blacklist Players that will not receive the message.
+     */
+    public static void broadcast(String msg, boolean translate, Player... blacklist) {
+        List<Player> players = Bukkit.getOnlinePlayers().stream().filter(p -> {
+            for (Player player : blacklist) {
+                if (player.getUniqueId().equals(p.getUniqueId())) return false;
+            }
+            return true;
+        }).collect(Collectors.toList());
+
+        for (Player player : players) {
+            send(msg, player, translate);
+        }
+    }
+
+    /**
+     * Broadcast a message to all players except blacklisted ones.
+     *
+     * @param msg       The message to be broadcast.
+     * @param blacklist Players that will not receive the message.
+     */
+    public static void broadcast(String msg, Player... blacklist) {
+        broadcast(msg, true, blacklist);
+    }
+
+    /**
+     * Broadcast a message to all players except blacklisted ones.
+     *
+     * @param msg         The message to be broadcast.
+     * @param translate   Convert the color codes.
+     * @param permissions Players with this perm will receive the message.
+     */
+    public static void broadcast(String msg, boolean translate, String... permissions) {
+        for (Player player : Bukkit.getOnlinePlayers()) {
+            if (hasPermission(player, permissions)) {
+                send(msg, player, translate);
+            }
+        }
+    }
+
+    /**
+     * Broadcast a message to all players except blacklisted ones.
+     *
+     * @param msg         The message to be broadcast.
+     * @param permissions Players with this perm will receive the message.
+     */
+    public static void broadcast(String msg, String... permissions) {
+        broadcast(msg, true, permissions);
+    }
+
+    /**
+     * Broadcast a message to all players.
+     *
+     * @param msgs      The message to be broadcast.
+     * @param translate Convert the color codes.
+     */
+    public static void broadcast(String[] msgs, boolean translate) {
+        for (Player player : Bukkit.getOnlinePlayers()) {
+            send(msgs, player, translate);
+        }
+    }
+
+    /**
+     * Broadcast a message to all players.
+     *
+     * @param msgs The message to be broadcast.
+     */
+    public static void broadcast(String[] msgs) {
+        broadcast(msgs, true);
+    }
+
+    /**
+     * Broadcast a message to all players.
+     *
+     * @param msgs        The message to be broadcast.
+     * @param sender      The sender of the message.
+     * @param permissions Convert the color codes if the sender has this permissions.
+     */
+    public static void broadcast(String[] msgs, Player sender, String... permissions) {
+        for (Player player : Bukkit.getOnlinePlayers()) {
+            send(msgs, player, sender, permissions);
+        }
+    }
+
+    /**
+     * Broadcast a message to all players.
+     *
+     * @param msgs        The message to be broadcast.
+     * @param sender      The sender of the message.
+     * @param permissions Convert the color codes if the sender has this permissions.
+     */
+    public static void broadcast(String[] msgs, CommandSender sender, String... permissions) {
+        for (Player player : Bukkit.getOnlinePlayers()) {
+            send(msgs, player, sender, permissions);
+        }
+    }
+
+    /**
+     * Broadcast a message to all players except blacklisted ones.
+     *
+     * @param msgs      The message to be broadcast.
+     * @param translate Convert the color codes.
+     * @param blacklist Players that will not receive the message.
+     */
+    public static void broadcast(String[] msgs, boolean translate, Player... blacklist) {
+        List<Player> players = Bukkit.getOnlinePlayers().stream().filter(p -> {
+            for (Player player : blacklist) {
+                if (player.getUniqueId().equals(p.getUniqueId())) return false;
+            }
+            return true;
+        }).collect(Collectors.toList());
+
+        for (Player player : players) {
+            send(msgs, player, translate);
+        }
+    }
+
+    /**
+     * Broadcast a message to all players except blacklisted ones.
+     *
+     * @param msgs      The message to be broadcast.
+     * @param blacklist Players that will not receive the message.
+     */
+    public static void broadcast(String[] msgs, Player... blacklist) {
+        broadcast(msgs, true, blacklist);
+    }
+
+    /**
+     * Broadcast a message to all players except blacklisted ones.
+     *
+     * @param msgs        The message to be broadcast.
+     * @param translate   Convert the color codes.
+     * @param permissions Players with this perm will receive the message.
+     */
+    public static void broadcast(String[] msgs, boolean translate, String... permissions) {
+        for (Player player : Bukkit.getOnlinePlayers()) {
+            if (hasPermission(player, permissions)) {
+                send(msgs, player, translate);
+            }
+        }
+    }
+
+    /**
+     * Broadcast a message to all players except blacklisted ones.
+     *
+     * @param msgs        The message to be broadcast.
+     * @param permissions Players with this perm will receive the message.
+     */
+    public static void broadcast(String[] msgs, String... permissions) {
+        broadcast(msgs, true, permissions);
+    }
+
+    /**
+     * Broadcast a message to all players.
+     *
+     * @param msgs      The message to be broadcast.
+     * @param translate Convert the color codes.
+     */
+    public static void broadcast(List<String> msgs, boolean translate) {
+        for (Player player : Bukkit.getOnlinePlayers()) {
+            send(msgs, player, translate);
+        }
+    }
+
+    /**
+     * Broadcast a message to all players.
+     *
+     * @param msgs The message to be broadcast.
+     */
+    public static void broadcast(List<String> msgs) {
+        broadcast(msgs, true);
+    }
+
+    /**
+     * Broadcast a message to all players.
+     *
+     * @param msgs        The message to be broadcast.
+     * @param sender      The sender of the message.
+     * @param permissions Convert the color codes if the sender has this permissions.
+     */
+    public static void broadcast(List<String> msgs, Player sender, String... permissions) {
+        for (Player player : Bukkit.getOnlinePlayers()) {
+            send(msgs, player, sender, permissions);
+        }
+    }
+
+    /**
+     * Broadcast a message to all players.
+     *
+     * @param msgs        The message to be broadcast.
+     * @param sender      The sender of the message.
+     * @param permissions Convert the color codes if the sender has this permissions.
+     */
+    public static void broadcast(List<String> msgs, CommandSender sender, String... permissions) {
+        for (Player player : Bukkit.getOnlinePlayers()) {
+            send(msgs, player, sender, permissions);
+        }
+    }
+
+    /**
+     * Broadcast a message to all players except blacklisted ones.
+     *
+     * @param msgs      The message to be broadcast.
+     * @param translate Convert the color codes.
+     * @param blacklist Players that will not receive the message.
+     */
+    public static void broadcast(List<String> msgs, boolean translate, Player... blacklist) {
+        List<Player> players = Bukkit.getOnlinePlayers().stream().filter(p -> {
+            for (Player player : blacklist) {
+                if (player.getUniqueId().equals(p.getUniqueId())) return false;
+            }
+            return true;
+        }).collect(Collectors.toList());
+
+        for (Player player : players) {
+            send(msgs, player, translate);
+        }
+    }
+
+    /**
+     * Broadcast a message to all players except blacklisted ones.
+     *
+     * @param msgs      The message to be broadcast.
+     * @param blacklist Players that will not receive the message.
+     */
+    public static void broadcast(List<String> msgs, Player... blacklist) {
+        broadcast(msgs, true, blacklist);
+    }
+
+    /**
+     * Broadcast a message to all players except blacklisted ones.
+     *
+     * @param msgs        The message to be broadcast.
+     * @param translate   Convert the color codes.
+     * @param permissions Players with this perm will receive the message.
+     */
+    public static void broadcast(List<String> msgs, boolean translate, String... permissions) {
+        for (Player player : Bukkit.getOnlinePlayers()) {
+            if (hasPermission(player, permissions)) {
+                send(msgs, player, translate);
+            }
+        }
+    }
+
+    /**
+     * Broadcast a message to all players except blacklisted ones.
+     *
+     * @param msgs        The message to be broadcast.
+     * @param permissions Players with this perm will receive the message.
+     */
+    public static void broadcast(List<String> msgs, String... permissions) {
+        broadcast(msgs, true, permissions);
+    }
+
+    /**
+     * Log a message to the console.
+     *
+     * @param msg   The message to log.
+     * @param level The log level.
+     */
+    public static void log(String msg, Level level) {
+        Bukkit.getLogger().log(level, getTranslated(msg));
+    }
+
+    /**
+     * Log a message to the console.
+     *
+     * @param msg The message to log.
+     */
+    public static void info(String msg) {
+        Bukkit.getLogger().info(getTranslated(msg));
+    }
+
+    /**
+     * Log a message to the console.
+     *
+     * @param msg The message to log.
+     */
+    public static void warning(String msg) {
+        Bukkit.getLogger().warning(getTranslated(msg));
+    }
+
+    /**
+     * Log a message to the console.
+     *
+     * @param msg The message to log.
+     */
+    public static void severe(String msg) {
+        Bukkit.getLogger().severe(getTranslated(msg));
+    }
+
+    private static boolean hasPermission(Player player, String... permissions) {
+        for (String perm : permissions) {
+            if (player.hasPermission(perm)) return true;
+        }
+
+        return false;
+    }
+}

--- a/src/main/java/it/multicoredev/nbtr/NBTRCommand.java
+++ b/src/main/java/it/multicoredev/nbtr/NBTRCommand.java
@@ -1,7 +1,5 @@
 package it.multicoredev.nbtr;
 
-import it.multicoredev.mbcore.spigot.Chat;
-import it.multicoredev.mbcore.spigot.util.TabCompleterUtil;
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandExecutor;
 import org.bukkit.command.CommandSender;

--- a/src/main/java/it/multicoredev/nbtr/NBTRecipes.java
+++ b/src/main/java/it/multicoredev/nbtr/NBTRecipes.java
@@ -1,6 +1,5 @@
 package it.multicoredev.nbtr;
 
-import it.multicoredev.mbcore.spigot.Chat;
 import it.multicoredev.mclib.json.GsonHelper;
 import it.multicoredev.mclib.json.TypeAdapter;
 import it.multicoredev.nbtr.listeners.OnInventoryChange;

--- a/src/main/java/it/multicoredev/nbtr/NBTRecipes.java
+++ b/src/main/java/it/multicoredev/nbtr/NBTRecipes.java
@@ -1,9 +1,13 @@
 package it.multicoredev.nbtr;
 
+import com.google.common.io.Files;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
 import it.multicoredev.mclib.json.GsonHelper;
 import it.multicoredev.mclib.json.TypeAdapter;
 import it.multicoredev.nbtr.listeners.OnInventoryChange;
 import it.multicoredev.nbtr.listeners.OnPlayerJoin;
+import it.multicoredev.nbtr.model.json.RecipeChoiceAdapter;
 import it.multicoredev.nbtr.model.recipes.RecipeWrapper;
 import it.multicoredev.nbtr.utils.MaterialAdapter;
 import org.bstats.bukkit.Metrics;
@@ -14,6 +18,7 @@ import org.bukkit.plugin.java.JavaPlugin;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
@@ -124,7 +129,11 @@ public class NBTRecipes extends JavaPlugin {
                 if (!file.getName().toLowerCase().endsWith(".json")) continue;
 
                 try {
-                    RecipeWrapper recipe = GSON.load(file, RecipeWrapper.class);
+                    final Gson gson = new GsonBuilder().setLenient().disableHtmlEscaping()
+                            .registerTypeAdapter(Material.class, new MaterialAdapter())
+                            .registerTypeAdapterFactory(new RecipeChoiceAdapter())
+                            .create();
+                    RecipeWrapper recipe = gson.fromJson(Files.newReader(file, StandardCharsets.UTF_8), RecipeWrapper.class);
                     if (recipe == null) continue;
                     if (!recipe.isValid()) {
                         Chat.warning("&eRecipe " + file.getName() + " is not valid");

--- a/src/main/java/it/multicoredev/nbtr/TabCompleterUtil.java
+++ b/src/main/java/it/multicoredev/nbtr/TabCompleterUtil.java
@@ -1,0 +1,188 @@
+package it.multicoredev.nbtr;
+
+import org.bukkit.Bukkit;
+import org.bukkit.entity.Player;
+import org.bukkit.metadata.MetadataValue;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Copyright © 2020 by Lorenzo Magni
+ * This file is part of MBCore.
+ * MBCore is under "The 3-Clause BSD License", you can find a copy <a href="https://opensource.org/licenses/BSD-3-Clause">here</a>.
+ * <p>
+ * Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+ * 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following
+ * disclaimer in the documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products
+ * derived from this software without specific prior written permission.
+ * <p>
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING,
+ * BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+ * OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+ * OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+public class TabCompleterUtil {
+
+    /**
+     * Get the list of player names starting with the searched characters.
+     *
+     * @param search       The starting characters of the names searched.
+     *                     If null or empty all player names will be returned.
+     * @param showVanished Choose to show vanished players (support Supervanish)
+     * @return A list of player names.
+     */
+    public static List<String> getPlayers(@Nullable String search, boolean showVanished) {
+        List<String> players = new ArrayList<>();
+
+        if (search == null || search.trim().isEmpty()) {
+            for (Player player : Bukkit.getOnlinePlayers()) {
+                if (isVanished(player) && !showVanished) continue;
+                players.add(player.getName());
+            }
+        } else {
+            for (Player player : Bukkit.getOnlinePlayers()) {
+                if (isVanished(player) && !showVanished) continue;
+                if (player.getName().toLowerCase().startsWith(search.toLowerCase())) players.add(player.getName());
+            }
+        }
+
+        return players;
+    }
+
+    /**
+     * Get the list of player names starting with the searched characters.
+     *
+     * @param search The starting characters of the names searched.
+     *               If null or empty all player names will be returned.
+     * @return A list of player names.
+     */
+    public static List<String> getPlayers(@Nullable String search) {
+        return getPlayers(search, true);
+    }
+
+    /**
+     * Get the list of player display names starting with the searched characters.
+     *
+     * @param search       The starting characters of the names searched.
+     *                     If null or empty all player names will be returned.
+     * @param showVanished Choose to show vanished players (support Supervanish)
+     * @return A list of player display names.
+     */
+    public static List<String> getDisplayNames(@Nullable String search, boolean showVanished) {
+        List<String> players = new ArrayList<>();
+
+        if (search == null || search.isEmpty()) {
+            for (Player player : Bukkit.getOnlinePlayers()) {
+                if (isVanished(player) && !showVanished) continue;
+                players.add(player.getDisplayName());
+            }
+        } else {
+            for (Player player : Bukkit.getOnlinePlayers()) {
+                if (isVanished(player) && !showVanished) continue;
+                if (player.getDisplayName().toLowerCase().startsWith(search.toLowerCase()))
+                    players.add(player.getDisplayName());
+            }
+        }
+
+        return players;
+    }
+
+    /**
+     * Get the list of player display names starting with the searched characters.
+     *
+     * @param search The starting characters of the names searched.
+     *               If null or empty all player names will be returned.
+     * @return A list of player display names.
+     */
+    public static List<String> getDisplayNames(@Nullable String search) {
+        return getDisplayNames(search, true);
+    }
+
+    /**
+     * Get a list of completions starting with the searched characters.
+     *
+     * @param search      The starting characters of the completions searched.
+     *                    If null or empty all completions will be returned.
+     * @param completions A list of completions.
+     * @return A list of completions.
+     */
+    public static List<String> getCompletions(@Nullable String search, @NotNull List<String> completions) {
+        Objects.requireNonNull(completions);
+        if (search == null || search.trim().isEmpty()) return completions;
+        List<String> matches = new ArrayList<>();
+
+        for (String completion : completions) {
+            if (!completion.toLowerCase().startsWith(search.toLowerCase())) continue;
+            matches.add(completion);
+        }
+
+        return matches;
+    }
+
+    /**
+     * Get a list of completions starting with the searched characters.
+     *
+     * @param search      The starting characters of the completions searched.
+     *                    If null or empty all completions will be returned.
+     * @param completions A list of completions.
+     * @return A list of completions.
+     */
+    public static List<String> getCompletions(@Nullable String search, @NotNull String... completions) {
+        Objects.requireNonNull(completions);
+        if (search == null || search.trim().isEmpty()) return Arrays.asList(completions);
+        List<String> matches = new ArrayList<>();
+
+        for (String completion : completions) {
+            if (!completion.toLowerCase().startsWith(search.toLowerCase())) continue;
+            matches.add(completion);
+        }
+
+        return matches;
+    }
+
+    /**
+     * Get the list of world names starting with the searched characters.
+     *
+     * @param search The starting characters of the names searched.
+     *               If null or empty all world names will be returned.
+     * @return A list of world names.
+     */
+    public static List<String> getWorlds(@Nullable String search) {
+        List<String> worlds = new ArrayList<>();
+
+        if (search == null || search.trim().isEmpty()) {
+            Bukkit.getWorlds().forEach(world -> worlds.add(world.getName()));
+        } else {
+            Bukkit.getWorlds().forEach(world -> {
+                if (world.getName().toLowerCase().startsWith(search.toLowerCase())) worlds.add(world.getName());
+            });
+        }
+
+        return worlds;
+    }
+
+    /**
+     * Check if a player is vanished using Supervanish.
+     *
+     * @param player The player to check.
+     * @return true if the player is vanished, false if he's not.
+     */
+    public static boolean isVanished(@NotNull Player player) {
+        Objects.requireNonNull(player);
+
+        for (MetadataValue meta : player.getMetadata("vanished")) {
+            if (meta.asBoolean()) return true;
+        }
+        return false;
+    }
+}

--- a/src/main/java/it/multicoredev/nbtr/model/Item.java
+++ b/src/main/java/it/multicoredev/nbtr/model/Item.java
@@ -2,7 +2,7 @@ package it.multicoredev.nbtr.model;
 
 import de.tr7zw.changeme.nbtapi.NBTContainer;
 import de.tr7zw.changeme.nbtapi.NBTItem;
-import it.multicoredev.mbcore.spigot.Chat;
+import it.multicoredev.nbtr.Chat;
 import org.bukkit.Material;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;

--- a/src/main/java/it/multicoredev/nbtr/model/json/RecipeChoiceAdapter.java
+++ b/src/main/java/it/multicoredev/nbtr/model/json/RecipeChoiceAdapter.java
@@ -1,0 +1,66 @@
+package it.multicoredev.nbtr.model.json;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonParseException;
+import com.google.gson.TypeAdapter;
+import com.google.gson.TypeAdapterFactory;
+import com.google.gson.reflect.TypeToken;
+import com.google.gson.stream.JsonReader;
+import com.google.gson.stream.JsonToken;
+import com.google.gson.stream.JsonWriter;
+import it.multicoredev.nbtr.model.Item;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.RecipeChoice;
+import org.jetbrains.annotations.NotNull;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public final class RecipeChoiceAdapter implements TypeAdapterFactory {
+
+    @Override @SuppressWarnings("unchecked") // Unchecked casts warnings can be suppressed as they should never fail.
+    public <T> TypeAdapter<T> create(final @NotNull Gson gson, final @NotNull TypeToken<T> type) {
+        if (type.getRawType().isAssignableFrom(RecipeChoice.class) == false)
+            return null;
+        // ...
+        return new TypeAdapter<T>() {
+
+            @Override
+            public T read(final JsonReader in) throws IOException {
+                // Reading as single object.
+                if (in.peek() == JsonToken.BEGIN_OBJECT) {
+                    System.out.println(1);
+                    final Item item = gson.getAdapter(Item.class).read(in);
+                    // ...
+                    if (item.isValid() == false)
+                        throw new JsonParseException(in.getPath() + ": Required field \"material\" does not exist.");
+                    // ...
+                    return (item.toItemStack().hasItemMeta() == false)
+                            ? (T) new RecipeChoice.MaterialChoice(item.toItemStack().getType())
+                            : (T) new RecipeChoice.ExactChoice(item.toItemStack());
+                }
+                // Reading as array of objects.
+                else if (in.peek() == JsonToken.BEGIN_ARRAY) {
+                    System.out.println(2);
+                    final List<Item> items = (List<Item>) gson.getAdapter(TypeToken.getParameterized(List.class, Item.class)).read(in);
+                    // ...
+                    if (items.stream().allMatch(Item::isValid) == false)
+                        throw new JsonParseException(in.getPath() + ": Required field \"material\" does not exist on one or more elements.");
+                    // ...
+                    return (items.stream().map(Item::toItemStack).allMatch(it -> it.hasItemMeta() == false) == true)
+                            ? (T) new RecipeChoice.MaterialChoice(items.stream().map(Item::toItemStack).map(ItemStack::getType).collect(Collectors.toList()))
+                            : (T) new RecipeChoice.ExactChoice(items.stream().map(Item::toItemStack).collect(Collectors.toList()));
+                }
+                // Throwing exception for unexpected input.
+                throw new JsonParseException(in.getPath() + ": Expected BEGIN_OBJECT or BEGIN_ARRAY but found " + in.peek());
+            }
+
+            @Override
+            public void write(final JsonWriter out, final T value) throws IOException {
+                throw new UnsupportedOperationException("NOT IMPLEMENTED");
+            }
+
+        };
+    }
+}

--- a/src/main/java/it/multicoredev/nbtr/model/recipes/BlastingRecipeWrapper.java
+++ b/src/main/java/it/multicoredev/nbtr/model/recipes/BlastingRecipeWrapper.java
@@ -1,7 +1,6 @@
 package it.multicoredev.nbtr.model.recipes;
 
 import org.bukkit.inventory.BlastingRecipe;
-import org.bukkit.inventory.RecipeChoice;
 
 /**
  * BSD 3-Clause License
@@ -48,7 +47,7 @@ public class BlastingRecipeWrapper extends FurnaceRecipeWrapper {
         return new BlastingRecipe(
                 namespacedKey,
                 result.toItemStack(),
-                new RecipeChoice.ExactChoice(input.toItemStack()),
+                recipeChoice,
                 experience,
                 cookingTime
         );

--- a/src/main/java/it/multicoredev/nbtr/model/recipes/CampfireRecipeWrapper.java
+++ b/src/main/java/it/multicoredev/nbtr/model/recipes/CampfireRecipeWrapper.java
@@ -1,7 +1,6 @@
 package it.multicoredev.nbtr.model.recipes;
 
 import org.bukkit.inventory.CampfireRecipe;
-import org.bukkit.inventory.RecipeChoice;
 
 /**
  * BSD 3-Clause License
@@ -45,6 +44,6 @@ public class CampfireRecipeWrapper extends FurnaceRecipeWrapper {
         if (experience == null || experience < 0) experience = 0f;
         if (cookingTime == null || cookingTime < 0) cookingTime = 200;
 
-        return new CampfireRecipe(namespacedKey, result.toItemStack(), new RecipeChoice.ExactChoice(input.toItemStack()), experience, cookingTime);
+        return new CampfireRecipe(namespacedKey, result.toItemStack(), recipeChoice, experience, cookingTime);
     }
 }

--- a/src/main/java/it/multicoredev/nbtr/model/recipes/FurnaceRecipeWrapper.java
+++ b/src/main/java/it/multicoredev/nbtr/model/recipes/FurnaceRecipeWrapper.java
@@ -1,8 +1,11 @@
 package it.multicoredev.nbtr.model.recipes;
 
+import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;
 import it.multicoredev.nbtr.model.Item;
+import it.multicoredev.nbtr.model.json.RecipeChoiceAdapter;
 import org.bukkit.inventory.Recipe;
+import org.bukkit.inventory.RecipeChoice;
 
 /**
  * BSD 3-Clause License
@@ -36,7 +39,8 @@ import org.bukkit.inventory.Recipe;
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 public abstract class FurnaceRecipeWrapper extends RecipeWrapper {
-    protected Item input;
+    @JsonAdapter(RecipeChoiceAdapter.class) @SerializedName("input")
+    protected RecipeChoice recipeChoice;
     protected Item result;
     protected Float experience;
     @SerializedName("cooking_time")
@@ -51,6 +55,6 @@ public abstract class FurnaceRecipeWrapper extends RecipeWrapper {
 
     @Override
     public boolean isValid() {
-        return input != null && input.isValid() && result != null && result.isValid();
+        return result != null && result.isValid();
     }
 }

--- a/src/main/java/it/multicoredev/nbtr/model/recipes/SmeltingRecipeWrapper.java
+++ b/src/main/java/it/multicoredev/nbtr/model/recipes/SmeltingRecipeWrapper.java
@@ -1,7 +1,6 @@
 package it.multicoredev.nbtr.model.recipes;
 
 import org.bukkit.inventory.FurnaceRecipe;
-import org.bukkit.inventory.RecipeChoice;
 
 /**
  * BSD 3-Clause License
@@ -48,7 +47,7 @@ public class SmeltingRecipeWrapper extends FurnaceRecipeWrapper {
         return new FurnaceRecipe(
                 namespacedKey,
                 result.toItemStack(),
-                new RecipeChoice.ExactChoice(input.toItemStack()),
+                recipeChoice,
                 experience,
                 cookingTime
         );

--- a/src/main/java/it/multicoredev/nbtr/model/recipes/SmokingRecipeWrapper.java
+++ b/src/main/java/it/multicoredev/nbtr/model/recipes/SmokingRecipeWrapper.java
@@ -48,7 +48,7 @@ public class SmokingRecipeWrapper extends FurnaceRecipeWrapper {
         return new SmokingRecipe(
                 namespacedKey,
                 result.toItemStack(),
-                new RecipeChoice.ExactChoice(input.toItemStack()),
+                recipeChoice,
                 experience,
                 cookingTime
         );


### PR DESCRIPTION
Opening as draft, as there is more work that have to be done. Please leave some feedback whether you want me to continue that, as I'm concerned it requires quite a bit of rewrite to recipe loading/registering.

### SCOPE OF THIS PR
- Add `RecipeChoice.MaterialChoice` support for recipes with no metadata specified.
- Allow users to specify multiple choices for one recipe, as that's something `RecipeChoice` is capable of taking care of, and is supported by datapacks.

```json
{
    "type": "smelting",
    "input": [
        { "material": "minecraft:obsidian" },
        { "material": "minecraft:bedrock" }
    ],
    "result": {
        "material": "minecraft:cooked_cod"
    },
    "experience": 0.35,
    "cooking_time": 200
}
```

### NOTES

Couldn't manage to get this working with `it.multicoredev.mclib.json.GsonHelper`, hence why there is new `Gson` instance created in the `NBTRecipes#loadRecipes` method (temporary solution). That might be entirely on my end, will take a proper look at this soon.

Existing and new functionality has not been fully tested but on the first glance, it works.

As you can see from the diff, we tend to follow different code style practices. I'll make sure to fix that before marking this PR as ready-for-review.

### TO-DO
- [ ] Figure out how to re-use `NBTRecipes.GSON` instance.
- [ ] Support remaining recipe types. (where applicable)
- [ ] Test if everything works as expected.
- [ ] Minimze code style difference.